### PR TITLE
Installation instruction update

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ and then as a dependency for the Package target utilizing OpenSSL:
 .target(
     name: "MyApp",
     dependencies: [
-        .product(name: "OpenSSL", package: "OpenSSL")
+        .product(name: "OpenSSL", package: "OpenSSL-Package")
     ]
 ),
 ```


### PR DESCRIPTION
Took me a while to make this work, maybe it's something wrong with my local setup, but looks like SPM will take the repo name as the package. 
Updating the instruction to use the correct dependency.

<img width="577" alt="image" src="https://github.com/krzyzanowskim/OpenSSL-Package/assets/173223508/4c34a840-c56c-494f-a6ba-6b1568265a3f">
